### PR TITLE
Fix clear_interrupt_pending_bit()

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -280,7 +280,7 @@ macro_rules! gpio {
 
                 /// Clear the interrupt pending bit for this pin
                 fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI) {
-                    exti.cpupr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
+                    exti.cpupr1.modify(|_r, w| unsafe { w.bits(1 << self.i) });
                 }
             }
 
@@ -703,7 +703,7 @@ macro_rules! gpio {
 
                     /// Clear the interrupt pending bit for this pin
                     fn clear_interrupt_pending_bit(&mut self, exti: &mut EXTI) {
-                        exti.cpupr1.modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
+                        exti.cpupr1.modify(|_r, w| unsafe { w.bits(1 << $i) });
                     }
                 }
 


### PR DESCRIPTION
According to RM0433, sec. 19.6.24, a "bit is cleared by writing a 1 into the bit or by changing the sensitivity of the edge detector."

I have not tested nor compiled this on stm32h7xx. However, I found this issue while porting the ExtiPin trait to stm32f1xx. I have tested this change on my stm32f1xx-hal working copy.
